### PR TITLE
add a global prisma client

### DIFF
--- a/src/app/api/categories/route.tsx
+++ b/src/app/api/categories/route.tsx
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server'
-import { PrismaClient } from "@prisma/client";
-const prisma = new PrismaClient();
+import prisma from '@/lib/prisma'
 
 export async function GET(request: Request) {
   const allCategories = await prisma.categories.findMany()

--- a/src/app/api/payments/route.tsx
+++ b/src/app/api/payments/route.tsx
@@ -1,7 +1,5 @@
 import { NextResponse } from 'next/server'
-import { PrismaClient } from "@prisma/client";
-import { CategoryScale } from 'chart.js';
-const prisma = new PrismaClient();
+import prisma from '@/lib/prisma'
 
 export async function GET(request: Request) {
   const allPayments = await prisma.payments.findMany()

--- a/src/app/api/users/route.tsx
+++ b/src/app/api/users/route.tsx
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server'
-import { PrismaClient } from "@prisma/client";
-const prisma = new PrismaClient();
+import prisma from '@/lib/prisma'
 
 export async function POST(request: Request) { 
   const body = await request.formData();

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,9 +1,16 @@
+// [Prisma client best practice](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/help-articles/nextjs-prisma-client-dev-practices)
 import { PrismaClient } from '@prisma/client'
 
-const globalForPrisma = global as unknown as { prisma: PrismaClient };
+const prismaClientSingleton = () => {
+  return new PrismaClient()
+}
 
-export const prisma = globalForPrisma.prisma || new PrismaClient();
+declare global {
+  var prismaGlobal: undefined | ReturnType<typeof prismaClientSingleton>
+}
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()
 
-export default prisma;
+export default prisma
+
+if (process.env.NODE_ENV !== 'production') globalThis.prismaGlobal = prisma

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+export default prisma;


### PR DESCRIPTION
To use a single prisma client across the app rather than creating a new one for each page.